### PR TITLE
[fix] 퀴즈 도메인 테스트코드 수정

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,6 +4,11 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
+  ai:
+    openai:
+      chat:
+        options:
+          model: "gemini-2.0-flash"
 
 custom:
   jwt:

--- a/src/test/java/com/back/backend/domain/quiz/daily/controller/DailyQuizControllerTest.java
+++ b/src/test/java/com/back/backend/domain/quiz/daily/controller/DailyQuizControllerTest.java
@@ -4,9 +4,7 @@ import com.back.backend.global.config.TestRqConfig;
 import com.back.backend.global.rq.TestRq;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
-import com.back.domain.quiz.detail.service.DetailQuizService;
 import com.back.global.rq.Rq;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,18 +30,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
         "NAVER_CLIENT_ID=test_client_id",
         "NAVER_CLIENT_SECRET=test_client_secret",
-        "GEMINI_API_KEY=api_key"
+        "HEALTHCHECK_URL=health_check_url",
 })
 @Import(TestRqConfig.class)
 public class DailyQuizControllerTest {
     @Autowired
-    private DetailQuizService detailQuizService;
-    @Autowired
     private MemberService memberService;
     @Autowired
     private MockMvc mvc;
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @Autowired
     private Rq rq;
@@ -128,7 +122,7 @@ public class DailyQuizControllerTest {
                 .andExpect(jsonPath("$.data.quizId").value(quizId))
                 .andExpect(jsonPath("$.data.selectedOption").value("OPTION2"))
                 .andExpect(jsonPath("$.data.correct").value(true))
-                .andExpect(jsonPath("$.data.gainExp").value(10))
+                .andExpect(jsonPath("$.data.gainExp").value(20))
                 .andExpect(jsonPath("$.data.quizType").value("DAILY"));
     }
 

--- a/src/test/java/com/back/backend/domain/quiz/detail/controller/DetailQuizControllerTest.java
+++ b/src/test/java/com/back/backend/domain/quiz/detail/controller/DetailQuizControllerTest.java
@@ -6,7 +6,6 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
 import com.back.domain.quiz.detail.dto.DetailQuizDto;
 import com.back.domain.quiz.detail.entity.Option;
-import com.back.domain.quiz.detail.service.DetailQuizService;
 import com.back.global.rq.Rq;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,12 +33,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
         "NAVER_CLIENT_ID=test_client_id",
         "NAVER_CLIENT_SECRET=test_client_secret",
-        "GEMINI_API_KEY=api_key"
+        "HEALTHCHECK_URL=health_check_url",
+        "GEMINI_API_KEY=gemini_api_key"
 })
 @Import(TestRqConfig.class)
 class DetailQuizControllerTest {
-    @Autowired
-    private DetailQuizService detailQuizService;
     @Autowired
     private MemberService memberService;
     @Autowired
@@ -49,8 +47,6 @@ class DetailQuizControllerTest {
 
     @Autowired
     private Rq rq;
-
-    private Member testMember;
 
 
     @BeforeEach

--- a/src/test/java/com/back/backend/domain/quiz/fact/controller/FactQuizControllerTest.java
+++ b/src/test/java/com/back/backend/domain/quiz/fact/controller/FactQuizControllerTest.java
@@ -4,9 +4,7 @@ import com.back.backend.global.config.TestRqConfig;
 import com.back.backend.global.rq.TestRq;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
-import com.back.domain.quiz.fact.service.FactQuizService;
 import com.back.global.rq.Rq;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,17 +30,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestPropertySource(properties = {
         "NAVER_CLIENT_ID=test_client_id",
         "NAVER_CLIENT_SECRET=test_client_secret",
+        "HEALTHCHECK_URL=health_check_url"
 })
 @Import(TestRqConfig.class)
 public class FactQuizControllerTest {
     @Autowired
-    private FactQuizService factQuizService;
-    @Autowired
     private MemberService memberService;
     @Autowired
     private MockMvc mvc;
-    @Autowired
-    private ObjectMapper objectMapper;
 
     @Autowired
     private Rq rq;
@@ -60,7 +55,6 @@ public class FactQuizControllerTest {
     @DisplayName("GET /api/quiz/detail - 팩트 퀴즈 목록 조회")
     void t1() throws Exception {
         //Given
-        int quizCount = (int) factQuizService.count();
 
         //When
         ResultActions resultActions = mvc.perform(get("/api/quiz/fact")
@@ -72,7 +66,8 @@ public class FactQuizControllerTest {
                 .andExpect(handler().methodName("getFactQuizzes"))
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("팩트 퀴즈 목록 조회 성공"))
-                .andExpect(jsonPath("$.data.length()").value(quizCount));
+                // TestInitData에 맞춰 설정한 기댓값
+                .andExpect(jsonPath("$.data.length()").value(3));
     }
 
     @Test
@@ -92,7 +87,7 @@ public class FactQuizControllerTest {
                 .andExpect(handler().methodName("getFactQuizzesByCategory"))
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("팩트 퀴즈 목록 조회 성공. 카테고리: " + category))
-                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data.length()").value(1))
                 .andExpect(jsonPath("$.data[0].id").isNumber())
                 .andExpect(jsonPath("$.data[0].realNewsTitle").value("인도 최대 IT 서비스 TCS 1만2200명 감원 계획"))
                 .andExpect(jsonPath("$.data[0].question").isString());


### PR DESCRIPTION
## 📢 기능 설명
퀴즈 도메인에서 변경된 로직에 맞추어 테스트코드 수정
- DailyQuiz 정답 제출시 받는 exp 기댓값 20으로 변경
- 팩트 퀴즈 다건 조회시 카테고리별 1개씩만 조회 -> 이에 맞추어 테스트코드 수정
- test properties 수정

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #3 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 테스트
  * 테스트 환경 속성 정비: HEALTHCHECK_URL 추가 및 AI 채팅 모델을 gemini-2.0-flash로 지정.
  * 일부 테스트 기대값 조정(예: 경험치 20) 및 목록 크기 검증을 고정 값 기반으로 안정화.
* 작업
  * 테스트 코드의 미사용 의존성 제거 및 정리로 빌드/실행 안정성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->