### PR TITLE
[refactor] RealNewsRepository 변환 #1

### DIFF
--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.kt
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.kt
@@ -5,178 +5,25 @@ import com.back.domain.news.real.entity.RealNews
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
-import java.util.*
 
-interface RealNewsRepository : JpaRepository<RealNews?, Long?> {
-    // 제목 검색 (Fulltext) + N번째 제외 (카테고리별 랭킹 제외)
-    @Query(
-        value = """
-    WITH ranked AS (
-        SELECT id,
-               ROW_NUMBER() OVER (PARTITION BY news_category ORDER BY created_date DESC) AS category_rank
-        FROM real_news
-        WHERE title_tsv @@ plainto_tsquery(:title)
-          AND id != :excludedId
-    )
-    SELECT rn.*
-    FROM real_news rn
-    WHERE rn.title_tsv @@ plainto_tsquery(:title)
-      AND rn.id != :excludedId
-      AND NOT EXISTS (
-          SELECT 1
-          FROM ranked
-          WHERE ranked.id = rn.id
-            AND ranked.category_rank = :excludedRank
-      )
-    ORDER BY rn.created_date DESC
-    
-    """.trimIndent(), countQuery = """
-    SELECT COUNT(*)
-    FROM real_news rn
-    WHERE rn.title_tsv @@ plainto_tsquery(:title)
-      AND rn.id != :excludedId
-    
-    """.trimIndent(), nativeQuery = true
-    )
-    fun findByTitleExcludingNthCategoryRank(
-        @Param("title") title: String?,
-        @Param("excludedId") excludedId: Long?,
-        @Param("excludedRank") excludedRank: Int,
-        pageable: Pageable?
-    ): Page<RealNews?>?
-
-    // 전체 조회에서 카테고리별 N번째 제외
-    @Query(
-        value = """
-    WITH ranked AS (
-        SELECT id,
-               ROW_NUMBER() OVER (PARTITION BY news_category ORDER BY created_date DESC) AS category_rank
-        FROM real_news
-        WHERE id != :excludedId
-    )
-    SELECT rn.*
-    FROM real_news rn
-    WHERE rn.id != :excludedId
-      AND NOT EXISTS (
-          SELECT 1 FROM ranked
-          WHERE ranked.id = rn.id
-            AND ranked.category_rank = :excludedRank
-      )
-    ORDER BY rn.created_date DESC
-    
-    """.trimIndent(), countQuery = """
-    SELECT COUNT(*)
-    FROM real_news rn
-    WHERE rn.id != :excludedId
-    
-    """.trimIndent(), nativeQuery = true
-    )
-    fun findAllExcludingNth(
-        @Param("excludedId") excludedId: Long?,
-        @Param("excludedRank") excludedRank: Int,
-        pageable: Pageable?
-    ): Page<RealNews?>?
-
-    // 카테고리별 조회에서 N번째 제외
-    @Query(
-        value = """
-    WITH ranked_news AS (
-        SELECT id,
-               ROW_NUMBER() OVER (ORDER BY created_date DESC) AS rank_num
-        FROM real_news
-        WHERE news_category = :#{#category.name()}
-          AND id != :excludedId
-    )
-    SELECT rn.*
-    FROM real_news rn
-    WHERE rn.news_category = :#{#category.name()}
-      AND rn.id != COALESCE((
-          SELECT r.id
-          FROM ranked_news r
-          WHERE r.rank_num = :excludedRank
-      ), 0)
-    ORDER BY rn.created_date DESC
-    
-    """.trimIndent(), countQuery = """
-    SELECT COUNT(*)
-    FROM real_news rn
-    WHERE rn.news_category = :#{#category.name()}
-      AND rn.id != :excludedId
-    
-    """.trimIndent(), nativeQuery = true
-    )
-    fun findByCategoryExcludingNth(
-        @Param("category") category: NewsCategory?,
-        @Param("excludedId") excludedId: Long?,
-        @Param("excludedRank") excludedRank: Int,
-        pageable: Pageable?
-    ): Page<RealNews?>?
-
-    // 모든 카테고리에서 N번째 순위 뉴스 조회
-    @Query(
-        value = """
-    SELECT rn.*
-    FROM (
-        SELECT id,
-               ROW_NUMBER() OVER (PARTITION BY news_category ORDER BY created_date DESC) AS rn
-        FROM real_news
-    ) AS sub
-    JOIN real_news rn ON rn.id = sub.id
-    WHERE sub.rn = :targetRank
-    ORDER BY rn.created_date DESC
-    
-    """.trimIndent(), nativeQuery = true
-    )
-    fun findNthRankByAllCategories(@Param("targetRank") targetRank: Int): MutableList<RealNews?>?
-
-    // 특정 카테고리에서 N번째 순위 뉴스 조회
-    @Query(
-        value = """
-    SELECT rn.*
-    FROM (
-        SELECT id,
-               ROW_NUMBER() OVER (ORDER BY created_date DESC) AS rn
-        FROM real_news
-        WHERE news_category = :#{#category.name()}
-    ) AS sub
-    JOIN real_news rn ON rn.id = sub.id
-    WHERE sub.rn = :targetRank
-    
-    """.trimIndent(), nativeQuery = true
-    )
-    fun findNthRankByCategory(
-        @Param("category") category: NewsCategory?,
-        @Param("targetRank") targetRank: Int
-    ): Optional<RealNews?>?
+interface RealNewsRepository : JpaRepository<RealNews, Long>, RealNewsRepositoryCustom {
 
     // 기본 전체 조회 (인덱스: idx_real_news_created_date_desc 직접 활용)
-    fun findAllByOrderByCreatedDateDesc(pageable: Pageable?): Page<RealNews?>?
+    fun findAllByOrderByCreatedDateDesc(pageable: Pageable): Page<RealNews>
 
-    // 카테고리별 조회 (인덱스: idx_real_news_category_created_date 직접 활용)
-    fun findByNewsCategoryOrderByCreatedDateDesc(category: NewsCategory?, pageable: Pageable?): Page<RealNews?>?
-
-    // ID 제외 조회들 (정렬 포함)
-    fun findByIdNotOrderByCreatedDateDesc(excludedId: Long?, pageable: Pageable?): Page<RealNews?>?
     fun findByNewsCategoryAndIdNotOrderByCreatedDateDesc(
-        category: NewsCategory?,
-        excludedId: Long?,
-        pageable: Pageable?
-    ): Page<RealNews?>?
+        category: NewsCategory,
+        excludedId: Long,
+        pageable: Pageable
+    ): Page<RealNews>
 
     fun findByTitleContainingAndIdNotOrderByCreatedDateDesc(
-        title: String?,
-        excludedId: Long?,
-        pageable: Pageable?
-    ): Page<RealNews?>?
+        title: String,
+        excludedId: Long,
+        pageable: Pageable
+    ): Page<RealNews>
 
-    // 날짜 범위 조회 - 정렬 추가로 인덱스 활용 개선
-    @Query("SELECT rn FROM RealNews rn WHERE rn.createdDate BETWEEN :start AND :end ORDER BY rn.createdDate DESC")
-    fun findByCreatedDateBetweenOrderByCreatedDateDesc(
-        @Param("start") start: LocalDateTime?,
-        @Param("end") end: LocalDateTime?
-    ): MutableList<RealNews?>?
+    fun findByCreatedDateBetweenOrderByCreatedDateDesc(start: LocalDateTime, end: LocalDateTime): List<RealNews>
+
 }
-

--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.kt
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepository.kt
@@ -1,21 +1,19 @@
-package com.back.domain.news.real.repository;
+package com.back.domain.news.real.repository
 
-import com.back.domain.news.common.enums.NewsCategory;
-import com.back.domain.news.real.entity.RealNews;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+import com.back.domain.news.common.enums.NewsCategory
+import com.back.domain.news.real.entity.RealNews
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
+import java.util.*
 
-
-public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
-
+interface RealNewsRepository : JpaRepository<RealNews?, Long?> {
     // 제목 검색 (Fulltext) + N번째 제외 (카테고리별 랭킹 제외)
-    @Query(value = """
+    @Query(
+        value = """
     WITH ranked AS (
         SELECT id,
                ROW_NUMBER() OVER (PARTITION BY news_category ORDER BY created_date DESC) AS category_rank
@@ -34,22 +32,25 @@ public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
             AND ranked.category_rank = :excludedRank
       )
     ORDER BY rn.created_date DESC
-    """,
-                countQuery = """
+    
+    """.trimIndent(), countQuery = """
     SELECT COUNT(*)
     FROM real_news rn
     WHERE rn.title_tsv @@ plainto_tsquery(:title)
       AND rn.id != :excludedId
-    """,
-            nativeQuery = true)
-    Page<RealNews> findByTitleExcludingNthCategoryRank(
-            @Param("title") String title,
-            @Param("excludedId") Long excludedId,
-            @Param("excludedRank") int excludedRank,
-            Pageable pageable);
+    
+    """.trimIndent(), nativeQuery = true
+    )
+    fun findByTitleExcludingNthCategoryRank(
+        @Param("title") title: String?,
+        @Param("excludedId") excludedId: Long?,
+        @Param("excludedRank") excludedRank: Int,
+        pageable: Pageable?
+    ): Page<RealNews?>?
 
     // 전체 조회에서 카테고리별 N번째 제외
-    @Query(value = """
+    @Query(
+        value = """
     WITH ranked AS (
         SELECT id,
                ROW_NUMBER() OVER (PARTITION BY news_category ORDER BY created_date DESC) AS category_rank
@@ -65,20 +66,23 @@ public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
             AND ranked.category_rank = :excludedRank
       )
     ORDER BY rn.created_date DESC
-    """,
-                countQuery = """
+    
+    """.trimIndent(), countQuery = """
     SELECT COUNT(*)
     FROM real_news rn
     WHERE rn.id != :excludedId
-    """,
-            nativeQuery = true)
-    Page<RealNews> findAllExcludingNth(
-            @Param("excludedId") Long excludedId,
-            @Param("excludedRank") int excludedRank,
-            Pageable pageable);
+    
+    """.trimIndent(), nativeQuery = true
+    )
+    fun findAllExcludingNth(
+        @Param("excludedId") excludedId: Long?,
+        @Param("excludedRank") excludedRank: Int,
+        pageable: Pageable?
+    ): Page<RealNews?>?
 
     // 카테고리별 조회에서 N번째 제외
-    @Query(value = """
+    @Query(
+        value = """
     WITH ranked_news AS (
         SELECT id,
                ROW_NUMBER() OVER (ORDER BY created_date DESC) AS rank_num
@@ -95,22 +99,25 @@ public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
           WHERE r.rank_num = :excludedRank
       ), 0)
     ORDER BY rn.created_date DESC
-    """,
-                countQuery = """
+    
+    """.trimIndent(), countQuery = """
     SELECT COUNT(*)
     FROM real_news rn
     WHERE rn.news_category = :#{#category.name()}
       AND rn.id != :excludedId
-    """,
-            nativeQuery = true)
-    Page<RealNews> findByCategoryExcludingNth(
-            @Param("category") NewsCategory category,
-            @Param("excludedId") Long excludedId,
-            @Param("excludedRank") int excludedRank,
-            Pageable pageable);
+    
+    """.trimIndent(), nativeQuery = true
+    )
+    fun findByCategoryExcludingNth(
+        @Param("category") category: NewsCategory?,
+        @Param("excludedId") excludedId: Long?,
+        @Param("excludedRank") excludedRank: Int,
+        pageable: Pageable?
+    ): Page<RealNews?>?
 
     // 모든 카테고리에서 N번째 순위 뉴스 조회
-    @Query(value = """
+    @Query(
+        value = """
     SELECT rn.*
     FROM (
         SELECT id,
@@ -120,12 +127,14 @@ public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     JOIN real_news rn ON rn.id = sub.id
     WHERE sub.rn = :targetRank
     ORDER BY rn.created_date DESC
-    """,
-                nativeQuery = true)
-        List<RealNews> findNthRankByAllCategories(@Param("targetRank") int targetRank);
+    
+    """.trimIndent(), nativeQuery = true
+    )
+    fun findNthRankByAllCategories(@Param("targetRank") targetRank: Int): MutableList<RealNews?>?
 
-        // 특정 카테고리에서 N번째 순위 뉴스 조회
-        @Query(value = """
+    // 특정 카테고리에서 N번째 순위 뉴스 조회
+    @Query(
+        value = """
     SELECT rn.*
     FROM (
         SELECT id,
@@ -135,26 +144,39 @@ public interface RealNewsRepository extends JpaRepository<RealNews, Long> {
     ) AS sub
     JOIN real_news rn ON rn.id = sub.id
     WHERE sub.rn = :targetRank
-    """,
-            nativeQuery = true)
-    Optional<RealNews> findNthRankByCategory(
-            @Param("category") NewsCategory category,
-            @Param("targetRank") int targetRank);
+    
+    """.trimIndent(), nativeQuery = true
+    )
+    fun findNthRankByCategory(
+        @Param("category") category: NewsCategory?,
+        @Param("targetRank") targetRank: Int
+    ): Optional<RealNews?>?
 
     // 기본 전체 조회 (인덱스: idx_real_news_created_date_desc 직접 활용)
-    Page<RealNews> findAllByOrderByCreatedDateDesc(Pageable pageable);
+    fun findAllByOrderByCreatedDateDesc(pageable: Pageable?): Page<RealNews?>?
 
     // 카테고리별 조회 (인덱스: idx_real_news_category_created_date 직접 활용)
-    Page<RealNews> findByNewsCategoryOrderByCreatedDateDesc(NewsCategory category, Pageable pageable);
+    fun findByNewsCategoryOrderByCreatedDateDesc(category: NewsCategory?, pageable: Pageable?): Page<RealNews?>?
+
     // ID 제외 조회들 (정렬 포함)
-    Page<RealNews> findByIdNotOrderByCreatedDateDesc(Long excludedId, Pageable pageable);
-    Page<RealNews> findByNewsCategoryAndIdNotOrderByCreatedDateDesc(NewsCategory category, Long excludedId, Pageable pageable);
-    Page<RealNews> findByTitleContainingAndIdNotOrderByCreatedDateDesc(String title, Long excludedId, Pageable pageable);
+    fun findByIdNotOrderByCreatedDateDesc(excludedId: Long?, pageable: Pageable?): Page<RealNews?>?
+    fun findByNewsCategoryAndIdNotOrderByCreatedDateDesc(
+        category: NewsCategory?,
+        excludedId: Long?,
+        pageable: Pageable?
+    ): Page<RealNews?>?
+
+    fun findByTitleContainingAndIdNotOrderByCreatedDateDesc(
+        title: String?,
+        excludedId: Long?,
+        pageable: Pageable?
+    ): Page<RealNews?>?
 
     // 날짜 범위 조회 - 정렬 추가로 인덱스 활용 개선
     @Query("SELECT rn FROM RealNews rn WHERE rn.createdDate BETWEEN :start AND :end ORDER BY rn.createdDate DESC")
-    List<RealNews> findByCreatedDateBetweenOrderByCreatedDateDesc(
-            @Param("start") LocalDateTime start,
-            @Param("end") LocalDateTime end);
+    fun findByCreatedDateBetweenOrderByCreatedDateDesc(
+        @Param("start") start: LocalDateTime?,
+        @Param("end") end: LocalDateTime?
+    ): MutableList<RealNews?>?
 }
 

--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepositoryCustom.kt
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepositoryCustom.kt
@@ -1,0 +1,39 @@
+package com.back.domain.news.real.repository
+
+import com.back.domain.news.common.enums.NewsCategory
+import com.back.domain.news.real.entity.RealNews
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface RealNewsRepositoryCustom {
+
+    // 기존 Native Query를 QueryDSL로 변환한 메서드들
+    fun findQByTitleExcludingNthCategoryRank(
+        title: String,
+        excludedId: Long,
+        excludedRank: Int,
+        pageable: Pageable
+    ): Page<RealNews>
+
+    fun findQAllExcludingNth(
+        excludedId: Long,
+        excludedRank: Int,
+        pageable: Pageable
+    ): Page<RealNews>
+
+    fun findQByCategoryExcludingNth(
+        category: NewsCategory,
+        excludedId: Long,
+        excludedRank: Int,
+        pageable: Pageable
+    ): Page<RealNews>
+
+    fun findQNthRankByAllCategories(targetRank: Int): List<RealNews>
+
+    fun findQNthRankByCategory(
+        category: NewsCategory,
+        targetRank: Int
+    ): RealNews?
+
+
+}

--- a/src/main/java/com/back/domain/news/real/repository/RealNewsRepositoryImpl.kt
+++ b/src/main/java/com/back/domain/news/real/repository/RealNewsRepositoryImpl.kt
@@ -1,0 +1,176 @@
+package com.back.domain.news.real.repository
+
+import com.back.domain.news.common.enums.NewsCategory
+import com.back.domain.news.real.entity.QRealNews
+import com.back.domain.news.real.entity.RealNews
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+
+@Repository
+class RealNewsRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : RealNewsRepositoryCustom {
+
+    private val qRealNews = QRealNews.realNews
+
+    override fun findQByTitleExcludingNthCategoryRank(
+        title: String,
+        excludedId: Long,
+        excludedRank: Int,
+        pageable: Pageable
+    ): Page<RealNews> {
+        // 1. 카테고리별 N번째 뉴스들의 ID를 먼저 조회
+        val excludedIds = NewsCategory.entries.mapNotNull { category ->
+            jpaQueryFactory
+                .select(qRealNews.id)
+                .from(qRealNews)
+                .where(
+                    qRealNews.newsCategory.eq(category)
+                        .and(qRealNews.id.ne(excludedId))
+                )
+                .orderBy(qRealNews.createdDate.desc())
+                .offset((excludedRank - 1).toLong())
+                .limit(1)
+                .fetchOne()
+        }
+
+        // 2. 제목 검색하되 위에서 찾은 ID들과 excludedId 제외
+        val allExcludedIds = excludedIds + excludedId
+
+        val total = jpaQueryFactory
+            .select(qRealNews.count())
+            .from(qRealNews)
+            .where(
+                qRealNews.title.containsIgnoreCase(title)
+                    .and(qRealNews.id.notIn(allExcludedIds))
+            )
+            .fetchOne() ?: 0L
+
+        val content = jpaQueryFactory
+            .selectFrom(qRealNews)
+            .where(
+                qRealNews.title.containsIgnoreCase(title)
+                    .and(qRealNews.id.notIn(allExcludedIds))
+            )
+            .orderBy(qRealNews.createdDate.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        return PageImpl(content, pageable, total)
+    }
+
+    override fun findQAllExcludingNth(
+        excludedId: Long,
+        excludedRank: Int,
+        pageable: Pageable
+    ): Page<RealNews> {
+        // 1. 각 카테고리별 N번째 뉴스 ID들 조회
+        val excludedIds = NewsCategory.entries.mapNotNull { category ->
+            jpaQueryFactory
+                .select(qRealNews.id)
+                .from(qRealNews)
+                .where(
+                    qRealNews.newsCategory.eq(category)
+                        .and(qRealNews.id.ne(excludedId))
+                )
+                .orderBy(qRealNews.createdDate.desc())
+                .offset((excludedRank - 1).toLong())
+                .limit(1)
+                .fetchOne()
+        }
+
+        // 2. 전체 조회하되 위에서 찾은 ID들과 excludedId 제외
+        val allExcludedIds = excludedIds + excludedId
+
+        val total = jpaQueryFactory
+            .select(qRealNews.count())
+            .from(qRealNews)
+            .where(qRealNews.id.notIn(allExcludedIds))
+            .fetchOne() ?: 0L
+
+        val content = jpaQueryFactory
+            .selectFrom(qRealNews)
+            .where(qRealNews.id.notIn(allExcludedIds))
+            .orderBy(qRealNews.createdDate.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        return PageImpl(content, pageable, total)
+    }
+
+    override fun findQByCategoryExcludingNth(
+        category: NewsCategory,
+        excludedId: Long,
+        excludedRank: Int,
+        pageable: Pageable
+    ): Page<RealNews> {
+        // 1. 해당 카테고리에서 N번째 뉴스 ID 조회
+        val excludedNthId = jpaQueryFactory
+            .select(qRealNews.id)
+            .from(qRealNews)
+            .where(
+                qRealNews.newsCategory.eq(category)
+                    .and(qRealNews.id.ne(excludedId))
+            )
+            .orderBy(qRealNews.createdDate.desc())
+            .offset((excludedRank - 1).toLong())
+            .limit(1)
+            .fetchOne()
+
+        // 2. 카테고리별 조회하되 N번째와 excludedId 제외
+        val excludeIds = listOfNotNull(excludedId, excludedNthId)
+
+        val total = jpaQueryFactory
+            .select(qRealNews.count())
+            .from(qRealNews)
+            .where(
+                qRealNews.newsCategory.eq(category)
+                    .and(qRealNews.id.notIn(excludeIds))
+            )
+            .fetchOne() ?: 0L
+
+        val content = jpaQueryFactory
+            .selectFrom(qRealNews)
+            .where(
+                qRealNews.newsCategory.eq(category)
+                    .and(qRealNews.id.notIn(excludeIds))
+            )
+            .orderBy(qRealNews.createdDate.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        return PageImpl(content, pageable, total)
+    }
+
+    override fun findQNthRankByAllCategories(targetRank: Int): List<RealNews> {
+        return NewsCategory.entries.mapNotNull { category ->
+            jpaQueryFactory
+                .selectFrom(qRealNews)
+                .where(qRealNews.newsCategory.eq(category))
+                .orderBy(qRealNews.createdDate.desc())
+                .offset((targetRank - 1).toLong())
+                .limit(1)
+                .fetchOne()
+        }.sortedByDescending { it.createdDate }
+    }
+
+    override fun findQNthRankByCategory(
+        category: NewsCategory,
+        targetRank: Int
+    ): RealNews? {
+        return jpaQueryFactory
+            .selectFrom(qRealNews)
+            .where(qRealNews.newsCategory.eq(category))
+            .orderBy(qRealNews.createdDate.desc())
+            .offset((targetRank - 1).toLong())
+            .limit(1)
+            .fetchOne()
+    }
+
+}

--- a/src/main/java/com/back/domain/news/real/service/RealNewsService.kt
+++ b/src/main/java/com/back/domain/news/real/service/RealNewsService.kt
@@ -56,7 +56,7 @@ class RealNewsService(
         val excludedId = todayNewsOrRecent
         val unsortedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
 
-        return realNewsRepository.findAllExcludingNth(excludedId, n + 1, unsortedPageable)
+        return realNewsRepository.findQAllExcludingNth(excludedId, n + 1, unsortedPageable)
             .map { realNews -> realNewsMapper.toDto(realNews) }
     }
 
@@ -65,7 +65,7 @@ class RealNewsService(
         val excludedId = todayNewsOrRecent
         val unsortedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
 
-        return realNewsRepository.findByTitleExcludingNthCategoryRank(title, excludedId, n + 1, unsortedPageable)
+        return realNewsRepository.findQByTitleExcludingNthCategoryRank(title, excludedId, n + 1, unsortedPageable)
             .map { realNews -> realNewsMapper.toDto(realNews) }
     }
 
@@ -74,7 +74,7 @@ class RealNewsService(
         val excludedId = todayNewsOrRecent
         val unsortedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize)
 
-        return realNewsRepository.findByCategoryExcludingNth(category, excludedId, n + 1, unsortedPageable)
+        return realNewsRepository.findQByCategoryExcludingNth(category, excludedId, n + 1, unsortedPageable)
             .map { realNews -> realNewsMapper.toDto(realNews) }
     }
 

--- a/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
+++ b/src/main/java/com/back/domain/quiz/fact/service/FactQuizService.java
@@ -42,7 +42,7 @@ public class FactQuizService {
 
     @Transactional(readOnly = true)
     public List<FactQuizDto> findByRank(int rank) {
-        List<RealNews> nthRankNews = realNewsRepository.findNthRankByAllCategories(rank);
+        List<RealNews> nthRankNews = realNewsRepository.findQNthRankByAllCategories(rank);
 
         // 해당 뉴스들의 FactQuiz 조회
         return nthRankNews.stream()
@@ -63,13 +63,13 @@ public class FactQuizService {
 
     @Transactional(readOnly = true)
     public Optional<FactQuizDto> findByCategoryAndRank(NewsCategory category, int rank) {
-        Optional<RealNews> realNews = realNewsRepository.findNthRankByCategory(category, rank);
+        RealNews realNews = realNewsRepository.findQNthRankByCategory(category, rank);
 
-        if (realNews.isEmpty()) {
+        if (realNews == null) {
             return Optional.empty();
         }
 
-        return factQuizRepository.findByRealNewsId(realNews.get().getId())
+        return factQuizRepository.findByRealNewsId(realNews.getId())
                 .map(FactQuizDto::new);
 
     }

--- a/src/main/java/com/back/global/ai/processor/NewsAnalysisProcessor.kt
+++ b/src/main/java/com/back/global/ai/processor/NewsAnalysisProcessor.kt
@@ -160,7 +160,7 @@ class NewsAnalysisProcessor(
             val results = rootNode.mapNotNull { itemNode ->
                 runCatching {
                     val newsIndex = itemNode.get("newsIndex")?.asInt()?.takeIf { it in 1..newsToAnalyze.size }
-                    val qualityScore = itemNode.get("qualityScore")?.asInt()
+                    val qualityScore = itemNode.get("qualityScore")?.asInt()?.takeIf{ it in 0..100}
                     val categoryString = itemNode.get("category")?.asText()?.takeIf { it.isNotBlank() }
                     val cleanedContent = itemNode.get("cleanedContent")?.asText()?.takeIf { it.isNotBlank() }
                     val category = categoryString?.let {

--- a/src/main/java/com/back/global/init/DevInitData.kt
+++ b/src/main/java/com/back/global/init/DevInitData.kt
@@ -100,7 +100,7 @@ class DevInitData(
             "https://n.news.naver.com/mnews/article/003/0013391031?sid=101",
             "https://imgnews.pstatic.net/image/003/2025/07/29/NISI20250729_0020908209_web_20250729134833_20250729134922533.jpg?type=w860",
             LocalDateTime.now().minusDays(2),
-            LocalDateTime.now().minusDays(1),
+            LocalDateTime.now().minusDays(1).minusSeconds(10),
             "뉴시스",
             "류현주 기자",
             "https://www.newsis.com/view/NISI20250729_0020908209",

--- a/src/main/java/com/back/global/jpa/JpaConfig.kt
+++ b/src/main/java/com/back/global/jpa/JpaConfig.kt
@@ -1,0 +1,14 @@
+package com.back.global.jpa
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JpaConfig(private val entityManager: EntityManager) {
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/test/java/com/back/backend/domain/quiz/daily/eventListener/DailyQuizEventListenerTest.java
+++ b/src/test/java/com/back/backend/domain/quiz/daily/eventListener/DailyQuizEventListenerTest.java
@@ -3,6 +3,7 @@ package com.back.backend.domain.quiz.daily.eventListener;
 import com.back.domain.news.real.service.NewsDataService;
 import com.back.domain.news.today.event.TodayNewsCreatedEvent;
 import com.back.domain.news.today.repository.TodayNewsRepository;
+import com.back.domain.news.today.service.TodayNewsService;
 import com.back.domain.quiz.daily.entity.DailyQuiz;
 import com.back.domain.quiz.daily.repository.DailyQuizRepository;
 import com.back.domain.quiz.detail.event.DetailQuizCreatedEvent;
@@ -37,6 +38,8 @@ import static org.awaitility.Awaitility.await;
 public class DailyQuizEventListenerTest {
     @Autowired
     private NewsDataService newsDataService;
+    @Autowired
+    private TodayNewsService todayNewsService;
     @Autowired
     private DailyQuizRepository dailyQuizRepository;
     @Autowired
@@ -87,7 +90,7 @@ public class DailyQuizEventListenerTest {
         Long todayNewsId = 5L;
 
         // When
-        newsDataService.setTodayNews(todayNewsId); // 내부에서 TodayNewsCreatedEvent 발행
+        todayNewsService.setTodayNews(todayNewsId); // 내부에서 TodayNewsCreatedEvent 발행
 
         // Then - 비동기 처리 완료 대기
         await().atMost(5, SECONDS).untilAsserted(() -> {


### PR DESCRIPTION
## 📢 기능 설명
1. global/jpa에 queryDSL 활용하기 위한 JpaConfig 설정

2. QueryDSL 사용한 위한 impl 구현
- findQByTitleExcludingNthCategoryRank -> fulltextSearch가 필요하지 않다고 판단하여 QueryDSL로 변경
- findQAllExcludingNth
- findQByCategoryExcludingNth
- findQNthRankByAllCategories
- findQNthRankByCategory

(기존 nativeQuery변경)



<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #94 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 뉴스 분석에서 qualityScore를 0~100 범위로 검증하여, 유효하지 않은 항목을 결과에서 제외해 비정상 데이터 노출을 방지했습니다.
- Refactor
  - 뉴스 목록/검색 쿼리 로직을 개선해 정렬 일관성과 응답 속도를 향상했습니다.
- Tests
  - 일일 퀴즈 이벤트 리스너 테스트가 최신 뉴스 서비스 경로를 사용하도록 업데이트했습니다.
- Chores
  - JPA 쿼리 팩토리 설정을 추가했습니다.
  - 개발 초기 데이터의 시간값을 소폭 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->