### PR TITLE
[refactor] DeatilQuiz Service 코드 수정 및 개선

### DIFF
--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizAsyncService.kt
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizAsyncService.kt
@@ -11,7 +11,6 @@ class DetailQuizAsyncService(
     private val detailQuizService: DetailQuizService,
     private val detailQuizRateLimitedService: DetailQuizRateLimitedService
 ) {
-    private val inProgressMap = ConcurrentHashMap<Long, Boolean>()
     private val inProgress = ConcurrentHashMap.newKeySet<Long>()
 
     @Async("quizExecutor")

--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizAsyncService.kt
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizAsyncService.kt
@@ -12,11 +12,12 @@ class DetailQuizAsyncService(
     private val detailQuizRateLimitedService: DetailQuizRateLimitedService
 ) {
     private val inProgressMap = ConcurrentHashMap<Long, Boolean>()
+    private val inProgress = ConcurrentHashMap.newKeySet<Long>()
 
     @Async("quizExecutor")
     fun generateAsync(newsId: Long): CompletableFuture<Void> {
-        if (inProgressMap.putIfAbsent(newsId, java.lang.Boolean.TRUE) != null) {
-            log.warn("이미 진행 중인 퀴즈 생성 작업이 있습니다. 뉴스 ID: $newsId")
+        if (!inProgress.add(newsId)) {
+            log.warn("이미 진행 중인 퀴즈 생성 작업이 있습니다. 뉴스 ID: {}", newsId)
             return CompletableFuture.completedFuture(null) // 이미 진행 중인 작업이 있으면 바로 반환
         }
 
@@ -27,13 +28,13 @@ class DetailQuizAsyncService(
             // 생성된 퀴즈 DB 저장
             detailQuizService.saveQuizzes(newsId, quizzes)
 
-            log.info("상세 퀴즈 생성 완료, 뉴스 ID: $newsId")
+            log.info("상세 퀴즈 생성 완료, 뉴스 ID: {}", newsId)
             CompletableFuture.completedFuture(null)
         } catch (e: Exception) {
             log.error("[실패] 뉴스 퀴즈 생성 실패 - newsId: {}, 오류: {}", newsId, e.message, e)
             CompletableFuture.completedFuture(null)
         } finally {
-            inProgressMap.remove(newsId)
+            inProgress.remove(newsId)
         }
     }
 

--- a/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.kt
+++ b/src/main/java/com/back/domain/quiz/detail/service/DetailQuizService.kt
@@ -16,7 +16,6 @@ import com.back.global.ai.processor.DetailQuizProcessor
 import com.back.global.exception.ServiceException
 import com.back.global.util.LevelSystem.calculateLevel
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -30,8 +29,6 @@ class DetailQuizService(
     private val quizHistoryRepository: QuizHistoryRepository,
     private val memberRepository: MemberRepository
 ) {
-    private val log = LoggerFactory.getLogger(DetailQuizService::class.java)
-
     fun count(): Long {
         return detailQuizRepository.count()
     }
@@ -67,10 +64,9 @@ class DetailQuizService(
 
     @Transactional(readOnly = true)
     fun findByNewsId(newsId: Long): List<DetailQuiz> {
-        val news = realNewsRepository.findById(newsId)
-            .orElseThrow {
-                ServiceException(404, "해당 id의 뉴스가 존재하지 않습니다. id: $newsId")
-            }
+        if (!realNewsRepository.existsById(newsId)) {
+            throw ServiceException(404, "해당 id의 뉴스가 존재하지 않습니다. id: $newsId")
+        }
 
         val quizzes = detailQuizRepository.findByRealNewsId(newsId)
 


### PR DESCRIPTION
## 📢 기능 설명
DeatilQuiz Service 코드 수정 및 개선
- 불필요한 로거 제거
- futureMap 구조로 변경해 퀴즈 생성 실패한 newsId 로그에 출력
- 동시 실행 가드 자료구조를 Set으로 변경
- findByNewsId에서 엔티티를 가져오지 않고 존재만 확인하도록 변경

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #120 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 동일 뉴스에 대한 상세 퀴즈 생성의 중복 동시 실행을 방지하여 안정성을 개선했습니다.
  - 비동기 처리 중 예외 발생 시 실패한 뉴스 ID를 특정해 복구 신뢰도를 높였습니다.
- 리팩터링
  - 진행 중 추적 방식과 로그 형식을 개선해 동시성 처리와 모니터링 가독성을 향상했습니다.
  - 뉴스 존재 여부를 경량 검증으로 전환해 조회 성능을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->